### PR TITLE
Implement dual-stream Finazon Kafka producer: high-frequency price ticks and full market data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .airflow/
 .idea/
+
+__pycache__/
+*.py[cod]

--- a/bdm/ingestion/streaming/finazon/README.md
+++ b/bdm/ingestion/streaming/finazon/README.md
@@ -43,7 +43,7 @@ The following environment variables need to be set:
 ```bash
 python -m bdm.ingestion.streaming.finazon.websocket_client \
   --price-ticks-topic price_ticks \
-  --volume-stream-topic volume_stream \
+  --stream-topic stream \
   --tickers AAPL,MSFT,GOOGL \
   --dataset us_stocks_essential
 ```
@@ -56,7 +56,7 @@ from bdm.ingestion.streaming.finazon.websocket_client import FinazonMarketDataPr
 # Initialize the producer
 producer = FinazonMarketDataProducer(
     price_ticks_topic="price_ticks",
-    volume_stream_topic="volume_stream",
+    stream_topic="stream",
     ticker_symbols=["AAPL", "MSFT", "GOOGL"],
     data_source="us_stocks_essential"
 )
@@ -70,7 +70,7 @@ producer.run()
 The module processes Finazon WebSocket data and outputs two Kafka streams:
 
 - **price_ticks_topic**: High-frequency price ticks (symbol, timestamp, price) interpolated every few ms using the event's timestamp for event time processing.
-- **volume_stream_topic**: Full market data event (all Finazon fields) every second.
+- **stream_topic**: Full market data event (all Finazon fields) every second.
 
 Each price tick message example:
 
@@ -82,22 +82,22 @@ Each price tick message example:
 }
 ```
 
-Each volume stream message example:
+Each stream message example:
 
 ```json
 {
-  "d": "us_stocks_essential",
-  "p": "finazon",
-  "ch": "bars",
-  "f": "1s",
-  "aggr": "1m",
-  "s": "AAPL",
-  "t": 1699540020,
-  "o": 220.06,
-  "h": 220.13,
-  "l": 219.92,
-  "c": 219.96,
-  "v": 4572
+  "data_source": "us_stocks_essential",
+  "provider": "finazon",
+  "channel": "bars",
+  "frequency": "1s",
+  "aggregation": "1m",
+  "symbol": "AAPL",
+  "timestamp": 1699540020,
+  "open_price": 220.06,
+  "close_price": 219.96,
+  "high_price": 220.13,
+  "low_price": 219.92,
+  "volume": 4572
 }
 ```
 

--- a/bdm/ingestion/streaming/finazon/README.md
+++ b/bdm/ingestion/streaming/finazon/README.md
@@ -1,0 +1,105 @@
+# Finazon Market Data Streaming Module
+
+A Python module for streaming market data from Finazon's WebSocket API to Kafka.
+
+## Features
+
+- Connect to Finazon's WebSocket API to receive real-time financial data
+- Subscribe to specific tickers (e.g., AAPL, MSFT) and data sources
+- Process and transform market data with descriptive field names
+- Interpolate 90 price points between the open and close prices
+- Publish interpolated data to Kafka for downstream processing
+- Auto-reconnect on connection errors with configurable retry parameters
+
+## Prerequisites
+
+- Python 3.8+
+- Access to a Kafka broker
+- Finazon API key (set as environment variable)
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+For development and testing:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+## Configuration
+
+The following environment variables need to be set:
+
+- `FINAZON_API_KEY`: Your Finazon API key
+- `KAFKA_ENDPOINT`: Kafka broker endpoint (default: localhost:9092)
+
+## Usage
+
+### Command Line
+
+```bash
+python -m bdm.ingestion.streaming.finazon.websocket_client \
+  --topic market_data \
+  --tickers AAPL,MSFT,GOOGL \
+  --dataset us_stocks_essential
+```
+
+### As a Library
+
+```python
+from bdm.ingestion.streaming.finazon.websocket_client import FinazonMarketDataProducer
+
+# Initialize the producer
+producer = FinazonMarketDataProducer(
+    kafka_topic="market_data",
+    ticker_symbols=["AAPL", "MSFT", "GOOGL"],
+    data_source="us_stocks_essential"
+)
+
+# Start receiving and publishing data
+producer.run()
+```
+
+## Data Format
+
+The module processes Finazon WebSocket data and interpolates 90 price points between the open and close prices. Each
+resulting message is formatted with descriptive field names:
+
+```json
+{
+  "data_source": "us_stocks_essential",
+  "provider": "finazon",
+  "channel": "bars",
+  "frequency": "1s",
+  "aggregation": "1m",
+  "symbol": "AAPL",
+  "timestamp": 1699540020,
+  "high_price": 220.13,
+  "low_price": 219.92,
+  "volume": 4572,
+  "price": 220.04
+}
+```
+
+The module will generate 90 messages for each market data update received from Finazon, with the price gradually
+changing from the open price to the close price.
+
+## Testing
+
+Run the tests with:
+
+```bash
+pytest bdm/ingestion/streaming/finazon/tests/
+```
+
+## License
+
+This project is licensed under the terms of the company's license.
+
+## Acknowledgements
+
+- [Finazon API](https://finazon.io/) - Financial data provider
+- [Kafka](https://kafka.apache.org/) - Distributed streaming platform 

--- a/bdm/ingestion/streaming/finazon/requirements-dev.txt
+++ b/bdm/ingestion/streaming/finazon/requirements-dev.txt
@@ -1,3 +1,6 @@
 pytest==8.3.5
 pytest-asyncio==0.26.0
 pytest-mock==3.14.0
+click==8.1.8
+kafka-python==2.1.1
+websockets==15.0.1

--- a/bdm/ingestion/streaming/finazon/requirements-dev.txt
+++ b/bdm/ingestion/streaming/finazon/requirements-dev.txt
@@ -1,6 +1,3 @@
 pytest==8.3.5
 pytest-asyncio==0.26.0
 pytest-mock==3.14.0
-click==8.1.8
-kafka-python==2.1.1
-websockets==15.0.1

--- a/bdm/ingestion/streaming/finazon/requirements-dev.txt
+++ b/bdm/ingestion/streaming/finazon/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest==8.3.5
+pytest-asyncio==0.26.0
+pytest-mock==3.14.0

--- a/bdm/ingestion/streaming/finazon/tests/__init__.py
+++ b/bdm/ingestion/streaming/finazon/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test package for Finazon WebSocket client module.
+"""

--- a/bdm/ingestion/streaming/finazon/tests/conftest.py
+++ b/bdm/ingestion/streaming/finazon/tests/conftest.py
@@ -62,16 +62,7 @@ def sample_market_data():
 def expected_processed_data():
     """Returns the expected processed market data."""
     return {
-        "data_source": "us_stocks_essential",
-        "provider": "finazon",
-        "channel": "bars",
-        "frequency": "1s",
-        "aggregation": "1m",
         "symbol": "AAPL",
         "timestamp": 1699540020,
-        "open_price": 220.06,
-        "high_price": 220.13,
-        "low_price": 219.92,
-        "close_price": 219.96,
-        "volume": 4572
+        "price": 220.06
     }

--- a/bdm/ingestion/streaming/finazon/tests/conftest.py
+++ b/bdm/ingestion/streaming/finazon/tests/conftest.py
@@ -1,0 +1,77 @@
+"""
+Pytest configuration file for Finazon WebSocket client tests.
+"""
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def mock_kafka_producer():
+    """Creates a mock for the KafkaProducer."""
+    with mock.patch('bdm.ingestion.streaming.finazon.websocket_client.KafkaProducer') as mock_producer_class:
+        # Create mock producer
+        mock_producer = mock.Mock()
+        mock_producer_class.return_value = mock_producer
+        yield mock_producer
+
+
+@pytest.fixture
+def mock_websocket_connect():
+    """Creates a mock for websockets.connect."""
+    with mock.patch('websockets.connect') as mock_connect:
+        # Create a mock websocket connection
+        mock_websocket = mock.AsyncMock()
+
+        # Configure the mock to return itself in the async context manager
+        mock_connect.return_value.__aenter__.return_value = mock_websocket
+
+        # Return both the connect function and the websocket object for assertions
+        yield mock_connect, mock_websocket
+
+
+@pytest.fixture
+def mock_sleep():
+    """Creates a mock for asyncio.sleep."""
+    with mock.patch('asyncio.sleep', autospec=True) as mock_sleep:
+        # Configure the mock to return immediately
+        mock_sleep.return_value = None
+        yield mock_sleep
+
+
+@pytest.fixture
+def sample_market_data():
+    """Returns sample market data from Finazon."""
+    return {
+        "d": "us_stocks_essential",
+        "p": "finazon",
+        "ch": "bars",
+        "f": "1s",
+        "aggr": "1m",
+        "s": "AAPL",
+        "t": 1699540020,
+        "o": 220.06,
+        "h": 220.13,
+        "l": 219.92,
+        "c": 219.96,
+        "v": 4572
+    }
+
+
+@pytest.fixture
+def expected_processed_data():
+    """Returns the expected processed market data."""
+    return {
+        "data_source": "us_stocks_essential",
+        "provider": "finazon",
+        "channel": "bars",
+        "frequency": "1s",
+        "aggregation": "1m",
+        "symbol": "AAPL",
+        "timestamp": 1699540020,
+        "open_price": 220.06,
+        "high_price": 220.13,
+        "low_price": 219.92,
+        "close_price": 219.96,
+        "volume": 4572
+    }

--- a/bdm/ingestion/streaming/finazon/tests/conftest.py
+++ b/bdm/ingestion/streaming/finazon/tests/conftest.py
@@ -4,6 +4,9 @@ Pytest configuration file for Finazon WebSocket client tests.
 from unittest import mock
 
 import pytest
+from flask.cli import load_dotenv
+
+load_dotenv()
 
 
 @pytest.fixture

--- a/bdm/ingestion/streaming/finazon/tests/test_websocket_client.py
+++ b/bdm/ingestion/streaming/finazon/tests/test_websocket_client.py
@@ -20,7 +20,7 @@ class TestFinazonMarketDataProducer:
         """Create a producer instance for testing."""
         return FinazonMarketDataProducer(
             price_ticks_topic="test_price_ticks",
-            volume_stream_topic="test_volume_stream",
+            stream_topic="test_stream",
             ticker_symbols=["AAPL", "MSFT"],
             data_source="us_stocks_essential"
         )
@@ -29,7 +29,7 @@ class TestFinazonMarketDataProducer:
     def test_init(producer, mock_kafka_producer):
         """Test initialization of the producer."""
         assert producer.price_ticks_topic == "test_price_ticks"
-        assert producer.volume_stream_topic == "test_volume_stream"
+        assert producer.stream_topic == "test_stream"
         assert producer.ticker_symbols == ["AAPL", "MSFT"]
         assert producer.data_source == "us_stocks_essential"
         assert producer.kafka_producer is mock_kafka_producer
@@ -202,7 +202,7 @@ class TestCommandLineInterface:
                 main,
                 [
                     '--price-ticks-topic', 'test_price_ticks',
-                    '--volume-stream-topic', 'test_volume_stream',
+                    '--stream-topic', 'test_stream',
                     '--tickers', 'AAPL,MSFT',
                     '--dataset', 'us_stocks_essential'
                 ]
@@ -210,7 +210,7 @@ class TestCommandLineInterface:
             assert result.exit_code == 0
             mock_producer_class.assert_called_once_with(
                 'test_price_ticks',
-                'test_volume_stream',
+                'test_stream',
                 ['AAPL', 'MSFT'],
                 'us_stocks_essential'
             )

--- a/bdm/ingestion/streaming/finazon/tests/test_websocket_client.py
+++ b/bdm/ingestion/streaming/finazon/tests/test_websocket_client.py
@@ -1,0 +1,218 @@
+"""
+Unit tests for Finazon WebSocket client functionality.
+"""
+import json
+from math import isclose
+from unittest import mock
+
+import pytest
+
+from bdm.ingestion.streaming.finazon.websocket_client import (
+    FinazonMarketDataProducer,
+    main
+)
+
+
+class TestFinazonMarketDataProducer:
+    """Tests for the FinazonMarketDataProducer class."""
+
+    @pytest.fixture
+    def producer(self, mock_kafka_producer):
+        """Create a producer instance for testing."""
+        return FinazonMarketDataProducer(
+            kafka_topic="test_topic",
+            ticker_symbols=["AAPL", "MSFT"],
+            data_source="us_stocks_essential"
+        )
+
+    @staticmethod
+    def test_init(producer, mock_kafka_producer):
+        """Test initialization of the producer."""
+        assert producer.kafka_topic == "test_topic"
+        assert producer.ticker_symbols == ["AAPL", "MSFT"]
+        assert producer.data_source == "us_stocks_essential"
+        assert producer.kafka_producer is mock_kafka_producer
+
+    @staticmethod
+    def test_validate_market_data_valid(producer, sample_market_data):
+        """Test validation with valid market data."""
+        assert FinazonMarketDataProducer._validate_market_data(sample_market_data) is True
+
+    @staticmethod
+    def test_validate_market_data_invalid(producer):
+        """Test validation with invalid market data."""
+        # Missing required fields
+        invalid_data = {"d": "us_stocks_essential", "p": "finazon"}
+        assert FinazonMarketDataProducer._validate_market_data(invalid_data) is False
+
+        # Missing one required field
+        partial_data = {
+            "d": "us_stocks_essential",
+            "p": "finazon",
+            "ch": "bars",
+            "s": "AAPL",
+            "t": 1699540020,
+            "o": 220.06,
+            "h": 220.13,
+            # Missing 'l' field
+            "c": 219.96,
+            "v": 4572
+        }
+        assert FinazonMarketDataProducer._validate_market_data(partial_data) is False
+
+    @pytest.mark.asyncio
+    async def test_send_interpolated_data(self, producer, sample_market_data, mock_sleep):
+        """Test interpolated data sending."""
+        # Call the method
+        await producer._send_interpolated_data(sample_market_data)
+
+        # Assert the data was sent to Kafka 90 times
+        assert producer.kafka_producer.send.call_count == 90
+
+        # Check the first interpolated message
+        first_call_args = producer.kafka_producer.send.call_args_list[0][0]
+        first_message = json.loads(first_call_args[1].decode())
+
+        # Topic should be correct
+        assert first_call_args[0] == "test_topic"
+
+        # Message should contain expected data
+        assert first_message["data_source"] == "us_stocks_essential"
+        assert first_message["symbol"] == "AAPL"
+        assert first_message["timestamp"] == 1699540020
+        assert isclose(first_message["high_price"], 220.13)
+        assert isclose(first_message["low_price"], 219.92)
+        assert first_message["volume"] == 4572
+
+        # First price should be close to open price
+        assert abs(first_message["price"] - 220.06) < 0.01
+
+        # Check last message to ensure interpolation reached close price
+        last_call_args = producer.kafka_producer.send.call_args_list[89][0]
+        last_message = json.loads(last_call_args[1].decode())
+
+        # Last price should be close to close price
+        assert abs(last_message["price"] - 219.96) < 0.01
+
+        # Sleep should have been called 90 times to control the rate
+        assert mock_sleep.call_count == 90
+
+    @pytest.mark.asyncio
+    async def test_handle_websocket_connection(self, producer, mock_websocket_connect, sample_market_data):
+        """Test handling WebSocket connection and processing messages."""
+        _, mock_websocket = mock_websocket_connect
+
+        # Configure the mock to provide a message then raise an exception to exit the loop
+        mock_websocket.__aiter__.return_value = [json.dumps(sample_market_data)]
+
+        # Mock the validation and processing methods
+        with mock.patch.object(FinazonMarketDataProducer, '_validate_market_data', return_value=True) as mock_validate, \
+                mock.patch.object(producer, '_send_interpolated_data') as mock_process:
+            await producer._handle_websocket_connection()
+
+            # Assert the subscription was sent
+            subscription_message = json.dumps({
+                "event": "subscribe",
+                "dataset": "us_stocks_essential",
+                "tickers": ["AAPL", "MSFT"],
+                "channel": "bars",
+                "frequency": "1s",
+                "aggregation": "1m"
+            })
+            mock_websocket.send.assert_called_once_with(subscription_message)
+
+            # Assert the market data was validated
+            mock_validate.assert_called_once_with(sample_market_data)
+
+            # Assert the market data was processed
+            mock_process.assert_called_once_with(sample_market_data)
+
+    @pytest.mark.asyncio
+    async def test_handle_websocket_invalid_data(self, producer, mock_websocket_connect):
+        """Test handling invalid WebSocket data."""
+        _, mock_websocket = mock_websocket_connect
+
+        # Configure the mock to provide an invalid message
+        invalid_data = {"d": "us_stocks_essential"}
+        mock_websocket.__aiter__.return_value = [json.dumps(invalid_data)]
+
+        # Mock the validation method to return False and the processing method
+        with mock.patch.object(FinazonMarketDataProducer, '_validate_market_data', return_value=False) as mock_validate, \
+                mock.patch.object(producer, '_send_interpolated_data') as mock_process, \
+                mock.patch('logging.warning') as mock_logging:
+            await producer._handle_websocket_connection()
+
+            # Assert the validation was called but processing was not
+            mock_validate.assert_called_once_with(invalid_data)
+            mock_process.assert_not_called()
+
+            # Assert a warning was logged
+            mock_logging.assert_called_once()
+
+    @staticmethod
+    def test_run(producer):
+        """Test the run method."""
+        # Create a regular Mock (not AsyncMock) to avoid coroutine warnings
+        mock_process = mock.Mock()
+
+        # Mock asyncio.run and the close method
+        with mock.patch.object(producer, '_process_market_data', mock_process), \
+                mock.patch('asyncio.run') as mock_run, \
+                mock.patch.object(producer.kafka_producer, 'close') as mock_close:
+            producer.run()
+
+            # Assert asyncio.run was called once (don't check the exact argument)
+            assert mock_run.call_count == 1
+
+            # Assert kafka producer was closed
+            mock_close.assert_called_once()
+
+    @staticmethod
+    def test_run_with_keyboard_interrupt(producer):
+        """Test the run method with keyboard interrupt."""
+        # We'll patch asyncio.run but test the real run method with a mock for _process_market_data
+        # Create a mock for _process_market_data that's not a coroutine
+        mock_process = mock.Mock()
+
+        def side_effect(*args, **kwargs):
+            raise KeyboardInterrupt()
+
+        with mock.patch('asyncio.run', side_effect=side_effect), \
+                mock.patch.object(producer, '_process_market_data', mock_process), \
+                mock.patch.object(producer.kafka_producer, 'close') as mock_close, \
+                mock.patch('logging.info') as mock_logging:
+            producer.run()
+
+            # Assert that asyncio.run was attempted to be called with our mocked method
+            # Assert shutdown message was logged
+            mock_logging.assert_called_once_with("Application shutdown requested")
+
+            # Assert kafka producer was closed
+            mock_close.assert_called_once()
+
+
+class TestCommandLineInterface:
+    """Tests for the command line interface."""
+
+    @staticmethod
+    def test_main():
+        """Test the main function."""
+        # Mock the FinazonMarketDataProducer class
+        with mock.patch(
+                'bdm.ingestion.streaming.finazon.websocket_client.FinazonMarketDataProducer') as mock_producer_class:
+            # Configure the mock
+            mock_producer = mock.Mock()
+            mock_producer_class.return_value = mock_producer
+
+            # Call the main function
+            main.callback(topic="test_topic", tickers="AAPL,MSFT", dataset="us_stocks_essential")
+
+            # Assert the producer was created with correct parameters
+            mock_producer_class.assert_called_once_with(
+                "test_topic",
+                ["AAPL", "MSFT"],
+                "us_stocks_essential"
+            )
+
+            # Assert run was called
+            mock_producer.run.assert_called_once()

--- a/bdm/ingestion/streaming/finazon/websocket_client.py
+++ b/bdm/ingestion/streaming/finazon/websocket_client.py
@@ -10,81 +10,123 @@ from kafka import KafkaProducer
 
 logging.basicConfig(level=logging.INFO)
 
-FINAZON_API = f"wss://ws.finazon.io/v1?apikey={os.environ['FINAZON_API_KEY']}"
+FINAZON_API_URL = f"wss://ws.finazon.io/v1?apikey={os.environ['FINAZON_API_KEY']}"
 
 
-class AssetTickProducer:
-    def __init__(self, topic: str, tickers: list[str], dataset: str, kafka_endpoint=os.getenv("KAFKA_ENDPOINT")):
-        self.topic = topic
-        self.tickers = tickers
-        self.dataset = dataset
-        self.producer = KafkaProducer(bootstrap_servers=[kafka_endpoint])
+class FinazonMarketDataProducer:
+    """
+    A class to connect to Finazon WebSocket API, receive market data and publish it to Kafka.
+    """
+
+    def __init__(self, kafka_topic: str, ticker_symbols: list[str], data_source: str,
+                 kafka_endpoint=os.getenv("KAFKA_ENDPOINT")):
+        self.kafka_topic = kafka_topic
+        self.ticker_symbols = ticker_symbols
+        self.data_source = data_source
+        self.kafka_producer = KafkaProducer(bootstrap_servers=[kafka_endpoint])
 
     def run(self):
+        """Start the market data producer."""
         try:
-            asyncio.run(self._process_stock_data())
+            asyncio.run(self._process_market_data())
         except KeyboardInterrupt:
             logging.info("Application shutdown requested")
         finally:
-            self.producer.close()
+            self.kafka_producer.close()
 
-    async def _process_stock_data(self) -> None:
-        reconnect_delay = 10
-        max_retries = 3
-        retries = 0
-        while retries < max_retries:
+    async def _process_market_data(self) -> None:
+        """Process market data with retry logic for connection issues."""
+        reconnect_delay_seconds = 10
+        max_reconnect_attempts = 3
+        reconnect_attempts = 0
+
+        while reconnect_attempts < max_reconnect_attempts:
             try:
                 await self._handle_websocket_connection()
-                retries = 0
-            except Exception as e:
-                logging.error("WebSocket error: %s", e)
-                retries += 1
-                if retries >= max_retries:
-                    logging.error("Max retries reached, failing hard.")
-                    raise e
-                await asyncio.sleep(reconnect_delay)
+                reconnect_attempts = 0
+            except Exception as error:
+                logging.error("WebSocket connection error: %s", error)
+                reconnect_attempts += 1
+                if reconnect_attempts >= max_reconnect_attempts:
+                    logging.error("Maximum reconnection attempts reached, exiting.")
+                    raise error
+                await asyncio.sleep(reconnect_delay_seconds)
 
     async def _handle_websocket_connection(self) -> None:
-        """Establish WebSocket connection and process messages."""
-        logging.info("Establishing WebSocket connection")
-        async with websockets.connect(FINAZON_API, ping_interval=30, ping_timeout=60) as ws:
-            await ws.send(json.dumps({
+        """Establish WebSocket connection and process incoming market data messages."""
+        logging.info("Establishing WebSocket connection to Finazon API")
+        async with websockets.connect(FINAZON_API_URL, ping_interval=30, ping_timeout=60) as websocket:
+            await websocket.send(json.dumps({
                 "event": "subscribe",
-                "dataset": self.dataset,
-                "tickers": self.tickers,
+                "dataset": self.data_source,
+                "tickers": self.ticker_symbols,
                 "channel": "bars",
                 "frequency": "1s",
                 "aggregation": "1m"
             }))
 
             # Process incoming messages
-            async for message in ws:
-                data = json.loads(message)
-                if 'o' not in data or 'c' not in data:
-                    logging.warning("Received message: %s", data)
+            async for message in websocket:
+                market_data = json.loads(message)
+                if not self._validate_market_data(market_data):
+                    logging.warning("Received incomplete market data: %s", market_data)
                     continue
 
-                await self._send_interpolated_data_async(data)
+                await self._send_interpolated_data(market_data)
 
-    async def _send_interpolated_data_async(self, data: Dict[str, Any]) -> None:
-        """Interpolates 90 messages asynchronously, ensuring no overlap."""
-        open_price = data['o']
-        close_price = data['c']
-        step = (close_price - open_price) / 90
+    @staticmethod
+    def _validate_market_data(market_data: Dict[str, Any]) -> bool:
+        """Validate that the market data contains all required fields."""
+        required_fields = ['o', 'c', 'h', 'l', 'v', 't', 's']
+        return all(field in market_data for field in required_fields)
 
+    async def _send_interpolated_data(self, market_data: Dict[str, Any]) -> None:
+        """Interpolates 90 price points between open and close prices and sends to Kafka."""
+        open_price = market_data['o']
+        close_price = market_data['c']
+        price_step = (close_price - open_price) / 90
+
+        # Create a well-structured base message with descriptive field names
+        base_message = {
+            "data_source": market_data.get('d', ''),
+            "provider": market_data.get('p', ''),
+            "channel": market_data.get('ch', ''),
+            "frequency": market_data.get('f', ''),
+            "aggregation": market_data.get('aggr', ''),
+            "symbol": market_data.get('s', ''),
+            "timestamp": market_data.get('t', 0),
+            "high_price": market_data.get('h', 0.0),
+            "low_price": market_data.get('l', 0.0),
+            "volume": market_data.get('v', 0)
+        }
+
+        # Send 90 interpolated price points
         for i in range(90):
-            price = round(open_price + i * step, 5)
-            self.producer.send(self.topic, json.dumps({"p": price}).encode())
+            # Calculate the interpolated price for this step
+            interpolated_price = round(open_price + i * price_step, 5)
+
+            # Create a message with the interpolated price
+            message = base_message.copy()
+            message["price"] = interpolated_price
+
+            # Send to Kafka
+            self.kafka_producer.send(
+                self.kafka_topic,
+                json.dumps(message).encode()
+            )
+
+            # Small delay to prevent overwhelming the broker
             await asyncio.sleep(0.01)
 
 
 @click.command()
-@click.option('--topic', help='Kafka topic to send data to.')
-@click.option('--tickers', help='Tickers to subscribe to.')
-@click.option('--dataset', help='Dataset to subscribe to.')
+@click.option('--topic', required=True, help='Kafka topic to send market data to.')
+@click.option('--tickers', required=True, help='Comma-separated list of ticker symbols to subscribe to.')
+@click.option('--dataset', required=True, help='Dataset identifier to subscribe to (e.g., us_stocks_essential).')
 def main(topic, tickers, dataset):
-    tickers_list = tickers.split(',')
-    producer = AssetTickProducer(topic, tickers_list, dataset)
+    """Command line interface to start the Finazon market data producer."""
+    ticker_symbols_list = tickers.split(',')
+    producer = FinazonMarketDataProducer(topic, ticker_symbols_list, dataset)
     producer.run()
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       context: ./bdm/ingestion/streaming/finazon
       dockerfile: Dockerfile
     container_name: finazon_stream_btc_usdt
-    command: [ "python", "websocket_client.py", "--price-ticks-topic", "btc_usdt_price_ticks", "--volume-stream-topic", "btc_usdt_volume_stream", "--tickers", "BTC/USDT", "--dataset", "crypto" ]
+    command: [ "python", "websocket_client.py", "--price-ticks-topic", "btc_usdt_price_ticks", "--stream-topic", "btc_usdt_stream", "--tickers", "BTC/USDT", "--dataset", "crypto" ]
     environment:
       - KAFKA_ENDPOINT=kafka:9092
       - FINAZON_API_KEY=${FINAZON_API_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       context: ./bdm/ingestion/streaming/finazon
       dockerfile: Dockerfile
     container_name: finazon_stream_btc_usdt
-    command: [ "python", "websocket_client.py", "--topic", "btc_usdt", "--tickers", "BTC/USDT", "--dataset", "crypto" ]
+    command: [ "python", "websocket_client.py", "--price-ticks-topic", "btc_usdt_price_ticks", "--volume-stream-topic", "btc_usdt_volume_stream", "--tickers", "BTC/USDT", "--dataset", "crypto" ]
     environment:
       - KAFKA_ENDPOINT=kafka:9092
       - FINAZON_API_KEY=${FINAZON_API_KEY}


### PR DESCRIPTION
This PR refactors the Finazon ingestion pipeline to produce two separate Kafka streams from the Finazon WebSocket API:

- **High-frequency price ticks stream** (`price_ticks_topic`):  
  Emits interpolated price tick events (symbol, timestamp, price) every few milliseconds for each received market data update. This enables hot-path, low-latency analytics and event-time processing.

- **Full market data stream** (`volume_stream_topic`):  
  Emits the complete Finazon event (all fields: open, close, high, low, volume, etc.) every second for each subscribed ticker. This enables warm-path, full-fidelity analytics and storage.

**Key changes:**
- The `FinazonMarketDataProducer` now takes two Kafka topic parameters and publishes to both.
- The CLI and Docker integration have been updated to use `--price-ticks-topic` and `--volume-stream-topic`.
- Unit tests and documentation have been updated to reflect the new dual-stream approach.
- The code is robust to connection issues and validates incoming data before publishing.

**Motivation:**  
Previously, only price data was streamed. After team discussion, we agreed to provide both high-frequency price ticks for real-time analytics and the full event for vwap calculation.

See previous PR #17 for the original single-stream approach and discussion.

**Example output:**

*Price tick message:*
```json
{
  "symbol": "AAPL",
  "timestamp": 1699540020,
  "price": 220.04
}
```
*Full event message:*
```json
{
  "d": "us_stocks_essential",
  "p": "finazon",
  "ch": "bars",
  "f": "1s",
  "aggr": "1m",
  "s": "AAPL",
  "t": 1699540020,
  "o": 220.06,
  "h": 220.13,
  "l": 219.92,
  "c": 219.96,
  "v": 4572
}
```
*Please review:*

-    The new dual-stream logic in websocket_client.py
-    The updated CLI and Docker usage
-    The revised tests and documentation